### PR TITLE
Replace ListItem with Row for contact list items

### DIFF
--- a/src/Main.kt
+++ b/src/Main.kt
@@ -212,23 +212,27 @@ fun Screen(contacts: List<Contact>) {
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 if (contacts.isEmpty()) {
-                    ListItem(
-                        headlineContent = { Text("No contacts found. Please update your address book.") },
-                        leadingContent = { Icon(Icons.Filled.Warning, contentDescription = "warning icon") }
-                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(Icons.Filled.Warning, contentDescription = "warning icon")
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text("No contacts found. Please update your address book.")
+                    }
                 } else {
                     contacts.forEachIndexed { index, it ->
-                        ListItem(
-                            headlineContent = {
-                                Text("${it.name} ${it.month + 1}/${it.day}${if ((it.year ?: 0) > 1) "/" + it.year else ""}")
-                            },
-                            leadingContent = {
-                                Icon(
-                                    if (index % 2 == 0) Icons.Filled.AccountCircle else Icons.Outlined.AccountCircle,
-                                    contentDescription = "account icon",
-                                )
-                            },
-                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                if (index % 2 == 0) Icons.Filled.AccountCircle else Icons.Outlined.AccountCircle,
+                                contentDescription = "account icon",
+                            )
+                            Spacer(modifier = Modifier.width(16.dp))
+                            Text("${it.name} ${it.month + 1}/${it.day}${if ((it.year ?: 0) > 1) "/" + it.year else ""}")
+                        }
                         HorizontalDivider()
                     }
                 }


### PR DESCRIPTION
## Summary
Refactored the contact list UI to use `Row` composables instead of `ListItem` for better control over layout and spacing.

## Key Changes
- Replaced `ListItem` composable with custom `Row` layouts for both the empty state and contact list items
- Added explicit padding (16.dp) and spacing between icon and text using `Spacer`
- Maintained all existing functionality including:
  - Warning icon display for empty contacts state
  - Alternating account icons (filled/outlined) based on index
  - Contact name and birthday formatting
  - Horizontal dividers between items

## Implementation Details
- Both the empty state and contact items now use a consistent `Row` structure with `fillMaxWidth()` modifier
- Icons and text are vertically centered using `Alignment.CenterVertically`
- Spacing between icon and text is now explicit (16.dp) rather than implicit in `ListItem`
- This change provides more flexibility for future UI customizations while maintaining the current visual appearance

https://claude.ai/code/session_01QXnDJ55KFQeqBZZniqfxXq