### PR TITLE
Update Android SDK versions to target API 35

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -13,6 +13,9 @@ dependencies:
 
 settings:
   android:
+    compileSdk: 35
+    targetSdk: 35
+    minSdk: 26
     applicationId: dev.sal.timekeeper
     versionCode: 2 # VERSION_CODE, overwritten in CI
     versionName: 0.0.0 # VERSION_NAME, overwritten in CI


### PR DESCRIPTION
## Summary
Updated the Android SDK configuration to target the latest API level while maintaining backward compatibility.

## Key Changes
- **compileSdk**: Updated to 35 (latest Android API level)
- **targetSdk**: Updated to 35 (aligns with compileSdk)
- **minSdk**: Set to 26 (maintains support for Android 8.0+)

## Details
These SDK version updates ensure the app is built against the latest Android APIs and targets the current platform version, while maintaining compatibility with Android 8.0 and later devices. This change is necessary for compliance with Google Play Store requirements and to access the latest Android platform features and security improvements.

https://claude.ai/code/session_01Rw4iDcE3M3tTn123DwMZbw