### PR TITLE
Update Amper to 0.9.2 and switch JRE to Zulu 25

### DIFF
--- a/amper
+++ b/amper
@@ -12,13 +12,14 @@
 #   AMPER_BOOTSTRAP_CACHE_DIR  Cache directory to store extracted JRE and Amper distribution
 #   AMPER_JAVA_HOME            JRE to run Amper itself (optional, does not affect compilation)
 #   AMPER_JAVA_OPTIONS         JVM options to pass to the JVM running Amper (does not affect the user's application)
+#   AMPER_NO_WELCOME_BANNER    Disables the first-run welcome message if set to a non-empty value
 
 set -e -u
 
 # The version of the Amper distribution to provision and use
-amper_version=0.8.0
+amper_version=0.9.2
 # Establish chain of trust from here by specifying exact checksum of Amper distribution to be run
-amper_sha256=c0ee60a755d8c6eeef5ca512abb36b15f2fd6a09c0e1a01b497cdb8097ad773d
+amper_sha256=33304bb301d0c5276ad4aa718ce8a10486fda4be45179779497d2036666bb16f
 
 AMPER_DOWNLOAD_ROOT="${AMPER_DOWNLOAD_ROOT:-https://packages.jetbrains.team/maven/p/amper/amper}"
 AMPER_JRE_DOWNLOAD_ROOT="${AMPER_JRE_DOWNLOAD_ROOT:-https:/}"
@@ -82,7 +83,7 @@ download_and_extract() {
     return 0;
   fi
 
-  if [ "$show_banner_on_cache_miss" = "true" ]; then
+  if [ "$show_banner_on_cache_miss" = "true" ] && [ -z "${AMPER_NO_WELCOME_BANNER:-}" ]; then
       echo
       echo '        _____  Welcome to                                  '
       echo '       /:::::|  ____   ___     ____      ____    __  ___   '
@@ -178,12 +179,14 @@ arch=$(uname -m)
 case "$kernelName" in
   Darwin* )
     simpleOs="macos"
-    jbr_os="osx"
+    jre_os="macosx"
+    jre_archive_type="tar.gz"
     default_amper_cache_dir="$HOME/Library/Caches/JetBrains/Amper"
     ;;
   Linux* )
     simpleOs="linux"
-    jbr_os="linux"
+    jre_os="linux"
+    jre_archive_type="tar.gz"
     default_amper_cache_dir="$HOME/.cache/JetBrains/Amper"
     # If linux runs in 32-bit mode, we want the "fake" 32-bit architecture, not the real hardware,
     # because in this mode linux cannot run 64-bit binaries.
@@ -192,7 +195,8 @@ case "$kernelName" in
     ;;
   CYGWIN* | MSYS* | MINGW* )
     simpleOs="windows"
-    jbr_os="windows"
+    jre_os="win"
+    jre_archive_type=zip
     if command -v cygpath >/dev/null 2>&1; then
       default_amper_cache_dir=$(cygpath -u "$LOCALAPPDATA\JetBrains\Amper")
     else
@@ -216,45 +220,50 @@ download_and_extract "Amper distribution v$amper_version" "$amper_url" "$amper_s
 
 if [ "x${AMPER_JAVA_HOME:-}" = "x" ]; then
   case $arch in
-    x86_64 | x64)    jbr_arch="x64" ;;
-    aarch64 | arm64) jbr_arch="aarch64" ;;
+    x86_64 | x64)    jre_arch="x64" ;;
+    aarch64 | arm64) jre_arch="aarch64" ;;
     *) die "Unsupported architecture $arch" ;;
   esac
 
   # Auto-updated from syncVersions.main.kts, do not modify directly here
-  jbr_version=21.0.8
-  jbr_build=b1038.68
+  zulu_version=25.28.85
+  java_version=25.0.0
 
-  # URL for JBR (vanilla) - see https://github.com/JetBrains/JetBrainsRuntime/releases
-  jbr_url="$AMPER_JRE_DOWNLOAD_ROOT/cache-redirector.jetbrains.com/intellij-jbr/jbr-$jbr_version-$jbr_os-$jbr_arch-$jbr_build.tar.gz"
-  jbr_target_dir="$amper_cache_dir/jbr-$jbr_version-$jbr_os-$jbr_arch-$jbr_build"
-
-  platform="$jbr_os $jbr_arch"
+  pkg_type=jre
+  platform="$jre_os $jre_arch"
   case $platform in
-    "osx x64")         jbr_sha512=40b57086c22a8feaea30b541a5e45b4c5ceb6ac2df11a7caae81f272e713be401a0a0e0241db271041e995805b68f2684f0deccc3a044a4b7d4c7562d74e9839 ;;
-    "osx aarch64")     jbr_sha512=e1212681d12d7b75a6fec39180d54b94d5cd63949c433f7552821c90783b0388f3a27eda712a6339fd2c21a25cc0b8a0846c5808ba7901e97e5c8a543dc6a55f ;;
-    "linux x64")       jbr_sha512=796337b4ff95e91fa0812d62d68f6952fcb19e2f62174756d33ebcbbade08137bd92169a96688f02f4131831baa0132210a4289d8e216757cb895f44ea9b2cd7 ;;
-    "linux aarch64")   jbr_sha512=cb047bf912395dd843c306e90ce4b4600c88f9bcb7742341d809d67d762bbb4e4edc936bc2be2589f7e5b050ad0513ba1a8deb6e0b481009d31e14aab9c2fe3b ;;
-    "windows x64")     jbr_sha512=b59b6c9dd5194c93c3b8512e788fea08cef97e6c1b9108591f72ecdddc6fdbd95999db1e44b382cb5c74202b5ae016da5aa1c21883cefe50c23f8d2d0f3f7434 ;;
-    "windows aarch64") jbr_sha512=fb784bf1c0842ff788479e05d65e7d6e7c92545d006a753a158e3f00d17a52fe0f8e4b0aa6081fabe0443219682ec03f726daacd7bf2ea28ddd31bd3ae7b7f22 ;;
+    "macosx x64")     jre_sha256=a73455c80413daa31af6b09589e3655bb8b8b91e4aa884ca7c91dc5552b9e974 ;;
+    "macosx aarch64") jre_sha256=37316ebea9709eb4f8bc58f0ddd2f58e53720d3e7df6f78c64125915b44d322d ;;
+    "linux x64")      jre_sha256=807e96e43db00af3390a591ed40f2c8c35f7f475fb14b6061dfb19db33702cba ;;
+    "linux aarch64")  jre_sha256=ad75e426e3f101cfa018f65fde07d82b10337d4f85250ca988474d59891c5f50 ;;
+    "win x64")        jre_sha256=d3c5db7864e6412ce3971c0b065def64942d7b0f3d02581f7f0472cac21fbba9 ;;
+    "win aarch64")    jre_sha256=f5f6d8a913695649e8e2607fe0dc79c81953b2583013ac1fb977c63cb4935bfb; pkg_type=jdk ;;
     *) die "Unsupported platform $platform" ;;
   esac
 
-  download_and_extract "JetBrains Runtime v$jbr_version$jbr_build" "$jbr_url" "$jbr_sha512" 512 "$amper_cache_dir" "$jbr_target_dir" "false"
+  # URL for the JRE (see https://api.azul.com/metadata/v1/zulu/packages?release_status=ga&include_fields=java_package_features,os,arch,hw_bitness,abi,java_package_type,sha256_hash,size,archive_type,lib_c_type&java_version=25&os=macos,linux,win)
+  # https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jre25.0.0-macosx_aarch64.tar.gz
+  # https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jre25.0.0-linux_x64.tar.gz
+  jre_url="$AMPER_JRE_DOWNLOAD_ROOT/cdn.azul.com/zulu/bin/zulu$zulu_version-ca-$pkg_type$java_version-${jre_os}_$jre_arch.$jre_archive_type"
+  jre_target_dir="$amper_cache_dir/zulu$zulu_version-ca-$pkg_type$java_version-${jre_os}_$jre_arch"
 
-  AMPER_JAVA_HOME=
-  for d in "$jbr_target_dir" "$jbr_target_dir"/* "$jbr_target_dir"/Contents/Home "$jbr_target_dir"/*/Contents/Home; do
+  download_and_extract "Amper runtime v$zulu_version" "$jre_url" "$jre_sha256" 256 "$amper_cache_dir" "$jre_target_dir" "false"
+
+  effective_amper_java_home=
+  for d in "$jre_target_dir" "$jre_target_dir"/* "$jre_target_dir"/Contents/Home "$jre_target_dir"/*/Contents/Home; do
     if [ -e "$d/bin/java" ]; then
-      AMPER_JAVA_HOME="$d"
+      effective_amper_java_home="$d"
     fi
   done
 
-  if [ "x${AMPER_JAVA_HOME:-}" = "x" ]; then
-    die "Unable to find bin/java under $jbr_target_dir"
+  if [ "x${effective_amper_java_home:-}" = "x" ]; then
+    die "Unable to find bin/java under $jre_target_dir"
   fi
+else
+  effective_amper_java_home="$AMPER_JAVA_HOME"
 fi
 
-java_exe="$AMPER_JAVA_HOME/bin/java"
+java_exe="$effective_amper_java_home/bin/java"
 if [ '!' -x "$java_exe" ]; then
   die "Unable to find bin/java executable at $java_exe"
 fi
@@ -267,18 +276,19 @@ wrapper_path=$(realpath "$0")
 # ********** Launch Amper **********
 
 # In this section we construct the command line by prepending arguments from biggest to lowest precedence:
-#   1. basic main class and classpath
+#   1. basic main class, CLI arguments, and classpath
 #   2. user JVM args (AMPER_JAVA_OPTIONS)
 #   3. default JVM args (prepended last, which means they appear first, so they are overridden by user args)
 
 # 1. Prepend basic launch arguments
 if [ "$simpleOs" = "windows" ]; then
-  libDirSlash="$(cygpath -w "$amper_target_dir")\lib\\"
+  # Can't cygpath the '*' so it has to be outside
+  classpath="$(cygpath -w "$amper_target_dir")\lib\*"
 else
-  libDirSlash="$amper_target_dir/lib/"
+  classpath="$amper_target_dir/lib/*"
 fi
 
-set -- -cp "$libDirSlash*" "-javaagent:${libDirSlash}kotlinx-coroutines-debug-1.10.2.jar" org.jetbrains.amper.cli.MainKt "$@"
+set -- -cp "$classpath" org.jetbrains.amper.cli.MainKt "$@"
 
 # 2. Prepend user JVM args from AMPER_JAVA_OPTS
 #
@@ -309,8 +319,7 @@ fi
 
 # 3. Prepend default JVM args
 set -- \
-    "-ea" \
-    "-XX:+EnableDynamicAgentLoading" \
+    @"$amper_target_dir/amper.args" \
     "-Damper.wrapper.dist.sha256=$amper_sha256" \
     "-Damper.dist.path=$amper_target_dir" \
     "-Damper.wrapper.path=$wrapper_path" \

--- a/amper.bat
+++ b/amper.bat
@@ -12,13 +12,14 @@
 @rem   AMPER_BOOTSTRAP_CACHE_DIR  Cache directory to store extracted JRE and Amper distribution
 @rem   AMPER_JAVA_HOME            JRE to run Amper itself (optional, does not affect compilation)
 @rem   AMPER_JAVA_OPTIONS         JVM options to pass to the JVM running Amper (does not affect the user's application)
+@rem   AMPER_NO_WELCOME_BANNER    Disables the first-run welcome message if set to a non-empty value
 
 setlocal
 
 @rem The version of the Amper distribution to provision and use
-set amper_version=0.8.0
+set amper_version=0.9.2
 @rem Establish chain of trust from here by specifying exact checksum of Amper distribution to be run
-set amper_sha256=c0ee60a755d8c6eeef5ca512abb36b15f2fd6a09c0e1a01b497cdb8097ad773d
+set amper_sha256=33304bb301d0c5276ad4aa718ce8a10486fda4be45179779497d2036666bb16f
 
 if not defined AMPER_DOWNLOAD_ROOT set AMPER_DOWNLOAD_ROOT=https://packages.jetbrains.team/maven/p/amper/amper
 if not defined AMPER_JRE_DOWNLOAD_ROOT set AMPER_JRE_DOWNLOAD_ROOT=https:/
@@ -48,7 +49,7 @@ if exist "%flag_file%" (
 
 @rem This multiline string is actually passed as a single line to powershell, meaning #-comments are not possible.
 @rem So here are a few comments about the code below:
-@rem  - we need to support both .zip and .tar.gz archives (for the Amper distribution and the JBR)
+@rem  - we need to support both .zip and .tar.gz archives (for the Amper distribution and the JRE)
 @rem  - tar should be present in all Windows machines since 2018 (and usable from both cmd and powershell)
 @rem  - tar requires the destination dir to exist
 @rem  - We use (New-Object Net.WebClient).DownloadFile instead of Invoke-WebRequest for performance. See the issue
@@ -67,7 +68,7 @@ if (-not $createdNew) { ^
  ^
 try { ^
     if ((Get-Content '%flag_file%' -ErrorAction Ignore) -ne '%sha%') { ^
-        if ('%show_banner_on_cache_miss%' -eq 'true') { ^
+        if (('%show_banner_on_cache_miss%' -eq 'true') -and [string]::IsNullOrEmpty('%AMPER_NO_WELCOME_BANNER%')) { ^
             Write-Host '*** Welcome to Amper v.%amper_version%! ***'; ^
             Write-Host ''; ^
             Write-Host 'This is the first run of this version, so we need to download the actual Amper distribution.'; ^
@@ -112,6 +113,9 @@ finally { ^
     $lock.ReleaseMutex(); ^
 }
 
+rem We reset the PSModulePath in case this batch script was called from PowerShell Core
+rem See https://github.com/PowerShell/PowerShell/issues/18108#issuecomment-2269703022
+set PSModulePath=
 set powershell=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe
 "%powershell%" -NonInteractive -NoProfile -NoLogo -Command %download_and_extract_ps1%
 if errorlevel 1 exit /b 1
@@ -131,7 +135,7 @@ call :download_and_extract "Amper distribution v%amper_version%" "%amper_url%" "
 if errorlevel 1 goto fail
 
 REM !! DO NOT REMOVE !!
-REM There is a command at the end of this line:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 exit /b %ERRORLEVEL%
+REM There is a command at the end of this line:                                                                                                                                                                                                                                                                                                                            exit /b %ERRORLEVEL%
 REM
 REM The above comment is strategically placed to compensate for a bug in the update command in Amper 0.5.0.
 REM During the update, the wrapper script is overwritten in-place while running. The problem is that cmd.exe doesn't
@@ -146,44 +150,62 @@ REM adjust the position of the exit command, hence the padding placeholder.
 
 REM ********** Provision JRE for Amper **********
 
-if defined AMPER_JAVA_HOME goto jre_provisioned
+if defined AMPER_JAVA_HOME (
+    if not exist "%AMPER_JAVA_HOME%\bin\java.exe" (
+      echo Invalid AMPER_JAVA_HOME provided: cannot find %AMPER_JAVA_HOME%\bin\java.exe
+      goto fail
+    )
+    @rem If AMPER_JAVA_HOME contains "jbr-21", it means we're inheriting it from the old Amper's update command.
+    @rem We must ignore it because Amper needs 25.
+    if "%AMPER_JAVA_HOME%"=="%AMPER_JAVA_HOME:jbr-21=%" (
+        set effective_amper_java_home=%AMPER_JAVA_HOME%
+        goto jre_provisioned
+    ) else (
+        echo WARN: AMPER_JAVA_HOME will be ignored because it points to a JBR 21, which is not valid for Amper anymore.
+        echo If you're updating from an Amper version older than 0.8.0, please ignore this message.
+    )
+)
 
 @rem Auto-updated from syncVersions.main.kts, do not modify directly here
-set jbr_version=21.0.8
-set jbr_build=b1038.68
+set zulu_version=25.28.85
+set java_version=25.0.0
 if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
-    set jbr_arch=aarch64
-    set jbr_sha512=fb784bf1c0842ff788479e05d65e7d6e7c92545d006a753a158e3f00d17a52fe0f8e4b0aa6081fabe0443219682ec03f726daacd7bf2ea28ddd31bd3ae7b7f22
+    set pkg_type=jdk
+    set jre_arch=aarch64
+    set jre_sha256=f5f6d8a913695649e8e2607fe0dc79c81953b2583013ac1fb977c63cb4935bfb
 ) else if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
-    set jbr_arch=x64
-    set jbr_sha512=b59b6c9dd5194c93c3b8512e788fea08cef97e6c1b9108591f72ecdddc6fdbd95999db1e44b382cb5c74202b5ae016da5aa1c21883cefe50c23f8d2d0f3f7434
+    set pkg_type=jre
+    set jre_arch=x64
+    set jre_sha256=d3c5db7864e6412ce3971c0b065def64942d7b0f3d02581f7f0472cac21fbba9
 ) else (
     echo Unknown Windows architecture %PROCESSOR_ARCHITECTURE% >&2
     goto fail
 )
 
-@rem URL for JBR (vanilla) - see https://github.com/JetBrains/JetBrainsRuntime/releases
-set jbr_url=%AMPER_JRE_DOWNLOAD_ROOT%/cache-redirector.jetbrains.com/intellij-jbr/jbr-%jbr_version%-windows-%jbr_arch%-%jbr_build%.tar.gz
-set jbr_target_dir=%AMPER_BOOTSTRAP_CACHE_DIR%\jbr-%jbr_version%-windows-%jbr_arch%-%jbr_build%
-call :download_and_extract "JetBrains Runtime v%jbr_version%%jbr_build%" "%jbr_url%" "%jbr_target_dir%" "%jbr_sha512%" "512" "false"
+@rem URL for the JRE (see https://api.azul.com/metadata/v1/zulu/packages?release_status=ga&include_fields=java_package_features,os,arch,hw_bitness,abi,java_package_type,sha256_hash,size,archive_type,lib_c_type&java_version=25&os=macos,linux,win)
+@rem https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jre25.0.0-win_x64.zip
+@rem https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jdk25.0.0-win_aarch64.zip
+set jre_url=%AMPER_JRE_DOWNLOAD_ROOT%/cdn.azul.com/zulu/bin/zulu%zulu_version%-ca-%pkg_type%%java_version%-win_%jre_arch%.zip
+set jre_target_dir=%AMPER_BOOTSTRAP_CACHE_DIR%\zulu%zulu_version%-ca-%pkg_type%%java_version%-win_%jre_arch%
+call :download_and_extract "Amper runtime v%zulu_version%" "%jre_url%" "%jre_target_dir%" "%jre_sha256%" "256" "false"
 if errorlevel 1 goto fail
 
-set AMPER_JAVA_HOME=
-for /d %%d in ("%jbr_target_dir%\*") do if exist "%%d\bin\java.exe" set AMPER_JAVA_HOME=%%d
-if not exist "%AMPER_JAVA_HOME%\bin\java.exe" (
-  echo Unable to find java.exe under %jbr_target_dir%
+set effective_amper_java_home=
+for /d %%d in ("%jre_target_dir%\*") do if exist "%%d\bin\java.exe" set effective_amper_java_home=%%d
+if not exist "%effective_amper_java_home%\bin\java.exe" (
+  echo Unable to find java.exe under %jre_target_dir%
   goto fail
 )
 :jre_provisioned
 
 REM ********** Launch Amper **********
 
-set jvm_args=-ea -XX:+EnableDynamicAgentLoading "-javaagent:%amper_target_dir%\lib\kotlinx-coroutines-debug-1.10.2.jar" %AMPER_JAVA_OPTIONS%
-"%AMPER_JAVA_HOME%\bin\java.exe" ^
+"%effective_amper_java_home%\bin\java.exe" ^
+  @"%amper_target_dir%\amper.args" ^
   "-Damper.wrapper.dist.sha256=%amper_sha256%" ^
   "-Damper.dist.path=%amper_target_dir%" ^
   "-Damper.wrapper.path=%~f0" ^
-  %jvm_args% ^
+  %AMPER_JAVA_OPTIONS% ^
   -cp "%amper_target_dir%\lib\*" ^
   org.jetbrains.amper.cli.MainKt ^
   %*

--- a/module.yaml
+++ b/module.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 settings:
   android:
-    compileSdk: 35
+    compileSdk: 36
     targetSdk: 35
     minSdk: 26
     applicationId: dev.sal.timekeeper


### PR DESCRIPTION
## Summary
This PR updates the Amper wrapper scripts to version 0.9.2 and replaces the JetBrains Runtime (JBR) 21 with Azul Zulu 25 as the runtime for Amper execution.

## Key Changes

### Version Updates
- Updated Amper version from 0.8.0 to 0.9.2
- Updated Amper distribution SHA256 checksum
- Switched JRE from JetBrains Runtime 21.0.8 to Azul Zulu 25.28.85 (Java 25.0.0)

### JRE Migration
- Replaced JBR with Azul Zulu JRE/JDK from `cdn.azul.com`
- Updated SHA256 checksums for all platform variants (macOS x64/aarch64, Linux x64/aarch64, Windows x64/aarch64)
- Changed Windows JRE archive format from `.tar.gz` to `.zip`
- Added logic to detect and ignore outdated JBR 21 references in `AMPER_JAVA_HOME`

### Script Improvements
- Added `AMPER_NO_WELCOME_BANNER` environment variable support to suppress first-run welcome message
- Fixed PowerShell module path issue by resetting `PSModulePath` before execution (Windows)
- Simplified JVM argument handling by moving default args to `amper.args` file reference
- Removed hardcoded kotlinx-coroutines-debug JAR from javaagent configuration
- Improved classpath construction for better cross-platform compatibility

### Documentation
- Updated environment variable documentation to include `AMPER_NO_WELCOME_BANNER`
- Updated comments to reflect JRE terminology instead of JBR

### Build Configuration
- Updated Android compileSdk from 35 to 36 in module.yaml

https://claude.ai/code/session_01CKFjxuRcNski2wLYkuhK1F