### PR TITLE
Remove changesNotSentForReview flag from Play Store deployment

### DIFF
--- a/.github/workflows/generate-and-publish-aab.yml
+++ b/.github/workflows/generate-and-publish-aab.yml
@@ -89,7 +89,6 @@ jobs:
           serviceAccountJson: ${{ steps.auth.outputs.credentials_file_path }}
           packageName: dev.sal.timekeeper
           releaseFiles: ${{ github.workspace }}/build/tasks/_TimeKeeper_bundleAndroid/gradle-project/build/_/outputs/bundle/release/gradle-project-release.aab
-          changesNotSentForReview: true
 
       - name: Upload the AAB
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Removed the `changesNotSentForReview: true` flag from the Google Play Store deployment step in the AAB generation and publishing workflow.

## Key Changes
- Removed the `changesNotSentForReview: true` parameter from the Play Store deployment action
- This allows the deployment to proceed with the default behavior for change review status

## Details
By removing this flag, the workflow will now use the default behavior of the Play Store deployment action, which typically means changes will be sent for review automatically rather than being held in draft status. This streamlines the release process by eliminating the manual step of submitting changes for review after deployment.

https://claude.ai/code/session_01XF5Jn9bdtg37tpsbRUeJxH