### PR TITLE
Update Amper to 0.10.0 and bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ render.experimental.xml
 # Keystore files
 *.jks
 *.keystore
+keystore.properties
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json

--- a/amper
+++ b/amper
@@ -17,9 +17,9 @@
 set -e -u
 
 # The version of the Amper distribution to provision and use
-amper_version=0.9.2
+amper_version=0.10.0
 # Establish chain of trust from here by specifying exact checksum of Amper distribution to be run
-amper_sha256=33304bb301d0c5276ad4aa718ce8a10486fda4be45179779497d2036666bb16f
+amper_sha256=d5ebdfb28a0a0bfcee2b942deb3c00a26b4ed9297b225490cf3009d468a47d85
 
 AMPER_DOWNLOAD_ROOT="${AMPER_DOWNLOAD_ROOT:-https://packages.jetbrains.team/maven/p/amper/amper}"
 AMPER_JRE_DOWNLOAD_ROOT="${AMPER_JRE_DOWNLOAD_ROOT:-https:/}"

--- a/amper.bat
+++ b/amper.bat
@@ -17,9 +17,9 @@
 setlocal
 
 @rem The version of the Amper distribution to provision and use
-set amper_version=0.9.2
+set amper_version=0.10.0
 @rem Establish chain of trust from here by specifying exact checksum of Amper distribution to be run
-set amper_sha256=33304bb301d0c5276ad4aa718ce8a10486fda4be45179779497d2036666bb16f
+set amper_sha256=d5ebdfb28a0a0bfcee2b942deb3c00a26b4ed9297b225490cf3009d468a47d85
 
 if not defined AMPER_DOWNLOAD_ROOT set AMPER_DOWNLOAD_ROOT=https://packages.jetbrains.team/maven/p/amper/amper
 if not defined AMPER_JRE_DOWNLOAD_ROOT set AMPER_JRE_DOWNLOAD_ROOT=https:/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [libraries]
-activity-compose = "androidx.activity:activity-compose:1.11.0"
-contacts-core = "com.github.vestrel00.contacts-android:core:0.4.0"
-material3 = "androidx.compose.material3:material3:1.4.0"
+activity-compose = "androidx.activity:activity-compose:1.13.0"
+contacts-core = "com.github.vestrel00.contacts-android:core:0.5.0"
 material-icons = "androidx.compose.material:material-icons-core:1.7.8"

--- a/module.yaml
+++ b/module.yaml
@@ -7,7 +7,6 @@ dependencies:
   - $compose.foundation
   - $compose.material3
   - $libs.activity.compose
-  - $libs.material3
   - $libs.material.icons
   - $libs.contacts.core
 


### PR DESCRIPTION
## Summary

- Upgrades Amper `0.9.2` → `0.10.0`, `activity-compose` `1.11.0` → `1.13.0`, and `contacts-core` `0.4.0` → `0.5.0`.
- Drops the redundant explicit `material3` library — `$compose.material3` already provides it via the Compose `1.10.3` catalog that Amper 0.10.0 ships with.
- Adds `keystore.properties` to `.gitignore` so local stubs (needed to work around the Amper Android plugin tripping a `NoSuchMethodError` when the file is missing) don't get committed.

## Why

`material-icons-core` was already at the latest stable `1.7.8`; everything else was a version or two behind. Amper 0.10.0 brings in Compose 1.10.3 / Kotlin 2.3.20 / KSP 2.3.6 — see the [release notes](https://github.com/JetBrains/amper/releases/tag/v0.10.0).

## Verified

- `./amper build` succeeds locally.
- Built a debug APK, installed it on a Pixel 3a API 34 AVD, and launched via the Maestro MCP:
  - App launches cleanly, Compose UI renders with the expected Material 3 purple buttons.
  - `contacts-core` 0.5.0 reads the emulator's default contacts (Abraham Lincoln 2/12, Martha Stewart 8/3).
  - Tapping "Create Calendars" handles the event without crashing.
  - No errors in `adb logcat` from `dev.sal.timekeeper`.

## Test plan

- [ ] Trigger the `Build and Publish Android App` workflow and confirm the release AAB still builds and uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)