### PR TITLE
Sync Birthdays calendar in the background

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# TimeKeeper
+
+Android app that copies birthday events from your Contacts into the system Calendar. A `WorkManager` job keeps the calendar in sync in the background — both periodically (daily) and reactively (whenever `ContactsContract` changes), so the calendar stays current without needing to open the app.
+
+## Building locally
+
+> [!IMPORTANT]
+> `./amper build` requires a `keystore.properties` file at the repo root, **even for debug builds**. If it's missing, Amper 0.10.0 hits a buggy error-reporting code path and the build fails with a misleading stack trace:
+>
+> ```
+> java.lang.NoSuchMethodError: 'void org.gradle.api.problems.ProblemReporter.reporting(org.gradle.api.Action)'
+>   at org.jetbrains.amper.android.gradle.AmperAndroidIntegrationProjectPlugin.apply(plugin.kt:144)
+> ```
+>
+> CI generates the real `keystore.properties` from secrets, so it isn't committed (`.gitignore` already excludes it). For local development, drop a placeholder at the repo root — the file just needs to exist; the values aren't read during debug builds:
+>
+> ```properties
+> storeFile=dummy.jks
+> storePassword=dummy
+> keyAlias=dummy
+> keyPassword=dummy
+> ```
+
+Then:
+
+```sh
+./amper build         # debug APK at build/tasks/_<module>_buildAndroidDebug/
+./amper run           # install + launch on a connected device/emulator
+```
+
+## UI tests (Maestro)
+
+Flows live under [`maestro/`](maestro/). With the app installed on a running emulator:
+
+```sh
+maestro test maestro/sync_now.yaml
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,3 +2,4 @@
 activity-compose = "androidx.activity:activity-compose:1.13.0"
 contacts-core = "com.github.vestrel00.contacts-android:core:0.5.0"
 material-icons = "androidx.compose.material:material-icons-core:1.7.8"
+work-runtime = "androidx.work:work-runtime-ktx:2.10.0"

--- a/maestro/sync_now.yaml
+++ b/maestro/sync_now.yaml
@@ -1,0 +1,35 @@
+appId: dev.sal.timekeeper
+---
+# Validates the new background-sync UI: Sync now button, last-synced label,
+# and idempotency of the underlying syncBirthdayCalendar() helper.
+- launchApp:
+    clearState: false
+- runFlow:
+    when:
+      visible: "Grant Permissions"
+    commands:
+      - tapOn: "Grant Permissions"
+      - tapOn: "Allow"
+      - tapOn: "Allow"
+      - tapOn: "Allow"
+- assertVisible: "Sync now"
+- assertVisible:
+    text: "Last synced:.*"
+- tapOn: "Sync now"
+- assertVisible:
+    text: "Syncing calendar\\.\\.\\."
+- assertVisible:
+    text: "Calendar synced"
+- assertVisible:
+    text: "Last synced:.*(seconds|minute|just now).*"
+# Tap twice more to assert idempotency: the label should keep updating, and
+# the calendar provider should not accumulate duplicate events (verify with:
+#   adb shell content query --uri content://com.android.calendar/events \
+#     --projection 'title' --where '"calendar_id=1"'
+# — expect one row per contact, not N copies after N taps).
+- tapOn: "Sync now"
+- assertVisible:
+    text: "Calendar synced"
+- tapOn: "Sync now"
+- assertVisible:
+    text: "Calendar synced"

--- a/module.yaml
+++ b/module.yaml
@@ -9,6 +9,7 @@ dependencies:
   - $libs.activity.compose
   - $libs.material.icons
   - $libs.contacts.core
+  - $libs.work.runtime
 
 settings:
   android:

--- a/src/AndroidManifest.xml
+++ b/src/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.WRITE_CALENDAR"/>
 
     <application
+            android:name="dev.sal.timekeeper.TimeKeeperApp"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name">
         <activity

--- a/src/CalendarSync.kt
+++ b/src/CalendarSync.kt
@@ -1,0 +1,175 @@
+package dev.sal.timekeeper
+
+import android.Manifest
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Color
+import android.provider.CalendarContract
+import androidx.core.content.ContextCompat
+import contacts.core.Contacts
+import contacts.core.entities.EventEntity
+import contacts.core.equalTo
+import contacts.core.invoke
+import contacts.core.util.events
+import contacts.core.util.names
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.Calendar
+import java.util.TimeZone
+
+internal const val PREFS_NAME = "timekeeper"
+internal const val KEY_LAST_SYNC_AT = "last_sync_at"
+
+private const val CALENDAR_DISPLAY_NAME = "Birthdays"
+private const val ACCOUNT_NAME = "TimeKeeper"
+private const val OWNER_ACCOUNT = "dev.sal.timekeeper"
+
+private val REQUIRED_PERMISSIONS = arrayOf(
+    Manifest.permission.READ_CONTACTS,
+    Manifest.permission.READ_CALENDAR,
+    Manifest.permission.WRITE_CALENDAR,
+)
+
+fun Context.hasSyncPermissions(): Boolean =
+    REQUIRED_PERMISSIONS.all {
+        ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED
+    }
+
+fun Context.loadBirthdayContacts(): List<Contact> =
+    Contacts(this)
+        .query()
+        .where {
+            Event { (Event.Type equalTo EventEntity.Type.BIRTHDAY) }
+        }.find()
+        .mapNotNull { contact ->
+            val (year, month, day) =
+                contact
+                    .events()
+                    .find { event -> event.type == EventEntity.Type.BIRTHDAY }
+                    ?.date
+                    ?.let {
+                        arrayOf(it.year ?: 0, it.month, it.dayOfMonth)
+                    } ?: return@mapNotNull null
+            val name = contact.names().firstOrNull()?.displayName ?: return@mapNotNull null
+            Contact(name = name, year = year, month = month, day = day)
+        }
+
+suspend fun Context.syncBirthdayCalendar(): Boolean = withContext(Dispatchers.IO) {
+    if (!hasSyncPermissions()) return@withContext false
+
+    val calendarId = contentResolver.getOrCreateBirthdayCalendar()
+    contentResolver.deleteEventsInCalendar(calendarId)
+    loadBirthdayContacts().forEach {
+        contentResolver.addBirthdayEvent(
+            name = it.name,
+            year = it.year,
+            month = it.month,
+            day = it.day,
+            calendarId = calendarId,
+        )
+    }
+    getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        .edit()
+        .putLong(KEY_LAST_SYNC_AT, System.currentTimeMillis())
+        .apply()
+    true
+}
+
+private fun ContentResolver.getOrCreateBirthdayCalendar(): Long =
+    getCalendarIdByName(CALENDAR_DISPLAY_NAME) ?: createCalendar()
+
+private fun ContentResolver.getCalendarIdByName(name: String): Long? {
+    val projection = arrayOf(
+        CalendarContract.Calendars._ID,
+        CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+        CalendarContract.Calendars.OWNER_ACCOUNT,
+    )
+    val selection =
+        "${CalendarContract.Calendars.CALENDAR_DISPLAY_NAME} = ? AND ${CalendarContract.Calendars.OWNER_ACCOUNT} = ?"
+    val selectionArgs = arrayOf(name, OWNER_ACCOUNT)
+
+    val cursor = query(
+        CalendarContract.Calendars.CONTENT_URI,
+        projection,
+        selection,
+        selectionArgs,
+        null,
+    )
+
+    return cursor?.use {
+        if (it.moveToFirst()) {
+            it.getLong(it.getColumnIndexOrThrow(CalendarContract.Calendars._ID))
+        } else {
+            null
+        }
+    }
+}
+
+private fun ContentResolver.createCalendar(): Long {
+    val values = ContentValues().apply {
+        put(CalendarContract.Calendars.ACCOUNT_NAME, ACCOUNT_NAME)
+        put(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL)
+        put(CalendarContract.Calendars.NAME, "Birthday Calendar")
+        put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, CALENDAR_DISPLAY_NAME)
+        put(CalendarContract.Calendars.CALENDAR_COLOR, Color.MAGENTA)
+        put(
+            CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
+            CalendarContract.Calendars.CAL_ACCESS_OWNER,
+        )
+        put(CalendarContract.Calendars.OWNER_ACCOUNT, OWNER_ACCOUNT)
+        put(CalendarContract.Calendars.CALENDAR_TIME_ZONE, TimeZone.getDefault().id)
+        put(CalendarContract.Calendars.SYNC_EVENTS, 1)
+    }
+
+    val uri = CalendarContract.Calendars.CONTENT_URI
+        .buildUpon()
+        .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+        .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, ACCOUNT_NAME)
+        .appendQueryParameter(
+            CalendarContract.Calendars.ACCOUNT_TYPE,
+            CalendarContract.ACCOUNT_TYPE_LOCAL,
+        ).build()
+
+    return insert(uri, values)?.lastPathSegment?.toLong() ?: -1
+}
+
+private fun ContentResolver.deleteEventsInCalendar(calendarId: Long) {
+    delete(
+        CalendarContract.Events.CONTENT_URI,
+        "${CalendarContract.Events.CALENDAR_ID} = ?",
+        arrayOf(calendarId.toString()),
+    )
+}
+
+private fun ContentResolver.addBirthdayEvent(
+    name: String,
+    year: Int?,
+    month: Int,
+    day: Int,
+    calendarId: Long,
+) {
+    val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+        set(Calendar.MONTH, month)
+        set(Calendar.DAY_OF_MONTH, day)
+        if (year != null && year != 0 && year != 1) {
+            set(Calendar.YEAR, year)
+        } else {
+            set(Calendar.YEAR, get(Calendar.YEAR))
+        }
+    }
+
+    val values = ContentValues().apply {
+        put(CalendarContract.Events.DTSTART, calendar.timeInMillis)
+        put(CalendarContract.Events.DURATION, "P1D")
+        put(CalendarContract.Events.TITLE, "$name's Birthday")
+        put(CalendarContract.Events.DESCRIPTION, "Birthday Event")
+        put(CalendarContract.Events.CALENDAR_ID, calendarId)
+        put(CalendarContract.Events.EVENT_TIMEZONE, calendar.timeZone.id)
+        put(CalendarContract.Events.ALL_DAY, 1)
+        put(CalendarContract.Events.RRULE, "FREQ=YEARLY")
+    }
+
+    insert(CalendarContract.Events.CONTENT_URI, values)
+}

--- a/src/CalendarSyncWorker.kt
+++ b/src/CalendarSyncWorker.kt
@@ -1,0 +1,60 @@
+package dev.sal.timekeeper
+
+import android.content.Context
+import android.provider.ContactsContract
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.util.concurrent.TimeUnit
+
+class CalendarSyncWorker(
+    ctx: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(ctx, params) {
+
+    override suspend fun doWork(): Result {
+        val outcome = runCatching { applicationContext.syncBirthdayCalendar() }
+        // Re-enqueue the one-time content-trigger work so we keep listening for
+        // contact changes. Content-URI triggers fire once and must be renewed.
+        schedule(applicationContext)
+        return outcome.fold(
+            onSuccess = { Result.success() },
+            onFailure = { Result.retry() },
+        )
+    }
+
+    companion object {
+        private const val UNIQUE_PERIODIC = "birthday-sync-periodic"
+        private const val UNIQUE_ON_CHANGE = "birthday-sync-on-change"
+
+        fun schedule(context: Context) {
+            val workManager = WorkManager.getInstance(context)
+
+            val periodic = PeriodicWorkRequestBuilder<CalendarSyncWorker>(1, TimeUnit.DAYS)
+                .build()
+            workManager.enqueueUniquePeriodicWork(
+                UNIQUE_PERIODIC,
+                ExistingPeriodicWorkPolicy.KEEP,
+                periodic,
+            )
+
+            val onChange = OneTimeWorkRequestBuilder<CalendarSyncWorker>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .addContentUriTrigger(ContactsContract.Contacts.CONTENT_URI, true)
+                        .build(),
+                )
+                .build()
+            workManager.enqueueUniqueWork(
+                UNIQUE_ON_CHANGE,
+                ExistingWorkPolicy.REPLACE,
+                onChange,
+            )
+        }
+    }
+}

--- a/src/Main.kt
+++ b/src/Main.kt
@@ -1,16 +1,14 @@
 package dev.sal.timekeeper
 
-import android.Manifest
 import android.app.Activity
-import android.content.ContentResolver
-import android.content.ContentValues
+import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.content.pm.PackageManager
-import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
-import android.provider.CalendarContract
 import android.provider.Settings
+import android.text.format.DateUtils
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
@@ -27,25 +25,20 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import contacts.core.Contacts
-import contacts.core.entities.EventEntity
-import contacts.core.equalTo
-import contacts.core.invoke
-import contacts.core.util.events
-import contacts.core.util.names
+import android.Manifest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.util.*
+import kotlinx.coroutines.withContext
 
 @Composable
 fun PermissionScreen(content: @Composable (List<Contact>) -> Unit) {
     val context = LocalContext.current
     val activity = context as? Activity
 
-    // Permissions we need
     val requiredPermissions =
         arrayOf(
             Manifest.permission.READ_CONTACTS,
@@ -53,7 +46,6 @@ fun PermissionScreen(content: @Composable (List<Contact>) -> Unit) {
             Manifest.permission.WRITE_CALENDAR,
         )
 
-    // State to hold whether permissions are granted
     var allPermissionsGranted by remember {
         mutableStateOf(
             requiredPermissions.all { permission ->
@@ -62,19 +54,15 @@ fun PermissionScreen(content: @Composable (List<Contact>) -> Unit) {
         )
     }
 
-    // State to hold whether permissions are denied permanently
     var permissionsDeniedPermanently by remember { mutableStateOf(false) }
 
-    // Launcher to request permissions
     val permissionsLauncher =
         rememberLauncherForActivityResult(
             RequestMultiplePermissions(),
         ) { permissions ->
-            // Update the state based on whether permissions are granted
             allPermissionsGranted = permissions.values.all { it }
 
             if (!allPermissionsGranted) {
-                // Check if any permission is denied permanently
                 permissionsDeniedPermanently =
                     permissions.entries.any { (permission, isGranted) ->
                         !isGranted &&
@@ -86,36 +74,14 @@ fun PermissionScreen(content: @Composable (List<Contact>) -> Unit) {
         }
 
     if (allPermissionsGranted) {
-        // Fetch contacts and display main content
-        val contactList by produceState(initialValue = emptyList()) {
-            value =
-                Contacts(context)
-                    .query()
-                    .where {
-                        Event { (Event.Type equalTo EventEntity.Type.BIRTHDAY) }
-                    }.find()
-                    .mapNotNull { contact ->
-                        val (year, month, day) =
-                            contact
-                                .events()
-                                .find { event -> event.type == EventEntity.Type.BIRTHDAY }
-                                ?.date
-                                ?.let {
-                                    arrayOf(it.year ?: 0, it.month, it.dayOfMonth)
-                                } ?: return@mapNotNull null
-                        val name = contact.names().firstOrNull()?.displayName ?: return@mapNotNull null
-                        Contact(
-                            name = name,
-                            year = year,
-                            month = month,
-                            day = day,
-                        )
-                    }
+        LaunchedEffect(Unit) {
+            CalendarSyncWorker.schedule(context.applicationContext)
         }
-
+        val contactList by produceState(initialValue = emptyList()) {
+            value = withContext(Dispatchers.IO) { context.loadBirthdayContacts() }
+        }
         content(contactList)
     } else if (permissionsDeniedPermanently) {
-        // Show message and button to open app settings
         Column(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.Center,
@@ -124,7 +90,6 @@ fun PermissionScreen(content: @Composable (List<Contact>) -> Unit) {
             Text("Permissions have been denied permanently. Please enable them in the app settings.")
             Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = {
-                // Open app settings
                 val intent =
                     Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
                         data = Uri.fromParts("package", context.packageName, null)
@@ -135,7 +100,6 @@ fun PermissionScreen(content: @Composable (List<Contact>) -> Unit) {
             }
         }
     } else {
-        // Show a button to request permissions
         Column(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.Center,
@@ -144,7 +108,6 @@ fun PermissionScreen(content: @Composable (List<Contact>) -> Unit) {
             Text("This app requires Contacts and Calendar permissions to function properly.")
             Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = {
-                // Request permissions
                 permissionsLauncher.launch(requiredPermissions)
             }) {
                 Text("Grant Permissions")
@@ -154,51 +117,65 @@ fun PermissionScreen(content: @Composable (List<Contact>) -> Unit) {
 }
 
 @Composable
+private fun rememberLastSyncedAt(): Long {
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE) }
+    var lastSyncedAt by remember { mutableLongStateOf(prefs.getLong(KEY_LAST_SYNC_AT, 0L)) }
+    DisposableEffect(prefs) {
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { sp, key ->
+            if (key == KEY_LAST_SYNC_AT) {
+                lastSyncedAt = sp.getLong(KEY_LAST_SYNC_AT, 0L)
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        onDispose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+    return lastSyncedAt
+}
+
+private fun formatLastSynced(timestamp: Long): String {
+    if (timestamp <= 0L) return "Last synced: never"
+    val relative = DateUtils.getRelativeTimeSpanString(
+        timestamp,
+        System.currentTimeMillis(),
+        DateUtils.MINUTE_IN_MILLIS,
+    )
+    return "Last synced: $relative"
+}
+
+@Composable
 fun Screen(contacts: List<Contact>) {
     val context = LocalContext.current
-    val contentResolver = context.contentResolver
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
+    val lastSyncedAt = rememberLastSyncedAt()
     MaterialTheme {
         Scaffold(
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
             bottomBar = {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(all = 16.dp),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(all = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Button(onClick = {
                         coroutineScope.launch {
-                            snackbarHostState.showSnackbar("Creating calendars...")
+                            snackbarHostState.showSnackbar("Syncing calendar...")
                         }
-                        coroutineScope.launch(Dispatchers.IO) {
-                            val calendarId = contentResolver.getOrCreateCalendar()
-                            contacts.forEach {
-                                contentResolver.addBirthdayEvent(
-                                    name = it.name,
-                                    year = it.year,
-                                    month = it.month,
-                                    day = it.day,
-                                    calendarId = calendarId,
-                                )
-                            }
-                        }
-                    }) {
-                        Text("Create Calendars")
-                    }
-                    Button(onClick = {
                         coroutineScope.launch {
-                            snackbarHostState.showSnackbar("Deleting calendars...")
-                        }
-                        coroutineScope.launch(Dispatchers.IO) {
-                            contentResolver.deletePreviousCalendars()
+                            val ok = context.syncBirthdayCalendar()
+                            snackbarHostState.showSnackbar(
+                                if (ok) "Calendar synced" else "Sync failed — check permissions",
+                            )
                         }
                     }) {
-                        Text("Delete Calendars")
+                        Text("Sync now")
                     }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = formatLastSynced(lastSyncedAt),
+                        style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center,
+                    )
                 }
             },
         ) { padding ->
@@ -248,132 +225,6 @@ class MainActivity : ComponentActivity() {
             PermissionScreen { contactList ->
                 Screen(contactList)
             }
-        }
-    }
-}
-
-private fun ContentResolver.getOrCreateCalendar(): Long {
-    val calendarId = getCalendarIdByName("Birthdays")
-    return calendarId ?: createCalendar()
-}
-
-private fun ContentResolver.getCalendarIdByName(name: String): Long? {
-    val projection =
-        arrayOf(
-            CalendarContract.Calendars._ID,
-            CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
-            CalendarContract.Calendars.OWNER_ACCOUNT,
-        )
-    val selection =
-        "${CalendarContract.Calendars.CALENDAR_DISPLAY_NAME} = ? AND ${CalendarContract.Calendars.OWNER_ACCOUNT} = ?"
-    val selectionArgs = arrayOf(name, "dev.sal.timekeeper")
-
-    val cursor =
-        this.query(
-            CalendarContract.Calendars.CONTENT_URI,
-            projection,
-            selection,
-            selectionArgs,
-            null,
-        )
-
-    return cursor?.use {
-        if (it.moveToFirst()) {
-            it.getLong(it.getColumnIndexOrThrow(CalendarContract.Calendars._ID))
-        } else {
-            null
-        }
-    }
-}
-
-private fun ContentResolver.createCalendar(): Long {
-    val values =
-        ContentValues().apply {
-            put(CalendarContract.Calendars.ACCOUNT_NAME, "TimeKeeper")
-            put(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL)
-            put(CalendarContract.Calendars.NAME, "Birthday Calendar")
-            put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, "Birthdays")
-            put(CalendarContract.Calendars.CALENDAR_COLOR, Color.MAGENTA)
-            put(
-                CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
-                CalendarContract.Calendars.CAL_ACCESS_OWNER,
-            )
-            put(CalendarContract.Calendars.OWNER_ACCOUNT, "dev.sal.timekeeper")
-            put(CalendarContract.Calendars.CALENDAR_TIME_ZONE, TimeZone.getDefault().id)
-            put(CalendarContract.Calendars.SYNC_EVENTS, 1)
-        }
-
-    val uri =
-        CalendarContract.Calendars.CONTENT_URI
-            .buildUpon()
-            .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
-            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, "TimeKeeper")
-            .appendQueryParameter(
-                CalendarContract.Calendars.ACCOUNT_TYPE,
-                CalendarContract.ACCOUNT_TYPE_LOCAL,
-            ).build()
-
-    val newUri = this.insert(uri, values)
-    return newUri?.lastPathSegment?.toLong() ?: -1
-}
-
-private fun ContentResolver.addBirthdayEvent(
-    name: String,
-    year: Int?,
-    month: Int,
-    day: Int,
-    calendarId: Long,
-) {
-    val calendar =
-        Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
-            set(Calendar.MONTH, month) // Months are 0-based in Calendar
-            set(Calendar.DAY_OF_MONTH, day)
-            if (year != null && year != 0 && year != 1) {
-                set(Calendar.YEAR, year)
-            } else {
-                // If year is not provided, use the current year
-                set(Calendar.YEAR, get(Calendar.YEAR))
-            }
-        }
-
-    val values =
-        ContentValues().apply {
-            put(CalendarContract.Events.DTSTART, calendar.timeInMillis)
-            put(CalendarContract.Events.DURATION, "P1D")
-            put(CalendarContract.Events.TITLE, "$name's Birthday")
-            put(CalendarContract.Events.DESCRIPTION, "Birthday Event")
-            put(CalendarContract.Events.CALENDAR_ID, calendarId)
-            put(CalendarContract.Events.EVENT_TIMEZONE, calendar.timeZone.id)
-            put(CalendarContract.Events.ALL_DAY, 1) // Make it an all-day event
-            put(CalendarContract.Events.RRULE, "FREQ=YEARLY") // Set the event to recur yearly
-        }
-
-    insert(CalendarContract.Events.CONTENT_URI, values)
-}
-
-private fun ContentResolver.deletePreviousCalendars() {
-    val selection =
-        "${CalendarContract.Calendars.ACCOUNT_NAME} = ? AND ${CalendarContract.Calendars.ACCOUNT_TYPE} = ?"
-    val selectionArgs = arrayOf("TimeKeeper", CalendarContract.ACCOUNT_TYPE_LOCAL)
-
-    val cursor =
-        this.query(
-            CalendarContract.Calendars.CONTENT_URI,
-            arrayOf(CalendarContract.Calendars._ID),
-            selection,
-            selectionArgs,
-            null,
-        )
-
-    cursor?.use {
-        while (it.moveToNext()) {
-            val calendarId = it.getLong(it.getColumnIndexOrThrow(CalendarContract.Calendars._ID))
-            val deleteUri =
-                CalendarContract.Calendars.CONTENT_URI
-                    .buildUpon()
-                    .appendPath(calendarId.toString())
-                    .build()
-            this.delete(deleteUri, null, null)
         }
     }
 }

--- a/src/TimeKeeperApp.kt
+++ b/src/TimeKeeperApp.kt
@@ -1,0 +1,10 @@
+package dev.sal.timekeeper
+
+import android.app.Application
+
+class TimeKeeperApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        CalendarSyncWorker.schedule(this)
+    }
+}


### PR DESCRIPTION
## Summary

- Birthdays calendar now refreshes automatically — no need to open the app. A `PeriodicWorkRequest` runs daily and a `OneTimeWorkRequest` with a `ContactsContract.Contacts.CONTENT_URI` trigger fires reactively whenever contacts change (re-enqueues itself each run since content-URI triggers are one-shot).
- Sync logic extracted into `Context.syncBirthdayCalendar()` and made idempotent: events inside the Birthdays calendar are wiped before re-insertion, so repeat runs don't duplicate. The previous **Create Calendars** button was non-idempotent (verified live — 2 taps produced 4 events for 2 contacts).
- Bottom bar simplified to a single **Sync now** button + "Last synced …" label. The label is driven by a `SharedPreferences.OnSharedPreferenceChangeListener` so it updates whether sync was triggered manually or by the worker.

## Implementation

- New `TimeKeeperApp : Application` schedules both workers on cold start; `PermissionScreen` also schedules them immediately when permissions are granted so users don't have to wait for the next launch.
- New files: `src/CalendarSync.kt` (sync logic + last-sync prefs), `src/CalendarSyncWorker.kt` (worker + `schedule()` companion), `src/TimeKeeperApp.kt`.
- `module.yaml` / `libs.versions.toml` pull in `androidx.work:work-runtime-ktx:2.10.0`; `AndroidManifest.xml` registers the Application class.
- README adds a prominent note about the missing-`keystore.properties` Amper 0.10.0 issue that surfaces as a misleading `NoSuchMethodError` — saves the next person from chasing the wrong stack trace.

## Test plan

- [x] `./amper build` succeeds (debug APK installed on Pixel 3a emulator, API 34).
- [x] [`maestro/sync_now.yaml`](maestro/sync_now.yaml) passes — 13/13 commands: launches app, taps **Sync now** three times, asserts `Syncing calendar…` / `Calendar synced` snackbars and the `Last synced:` label.
- [x] Idempotency: after 3 consecutive **Sync now** taps, `adb shell content query --uri content://com.android.calendar/events --where 'calendar_id=1'` returns exactly 2 rows (one per birthday contact), not 6.
- [x] Background scheduling: `adb shell dumpsys jobscheduler` shows two `androidx.work.systemjobscheduler` jobs registered for `dev.sal.timekeeper` — one DEFAULT priority (daily periodic), one HIGH priority (`ContactsContract` content-URI trigger), both `RUNNABLE` and `ALLOWED_IN_DOZE`.
- [ ] Reactive trigger end-to-end: with the app closed, edit a contact's birthday and confirm the Birthdays calendar updates within a minute. (Not exercised on the emulator in this pass — emulator contacts were not mutated after install.)